### PR TITLE
Compose and execute disjunction of basic patterns

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -76,7 +76,7 @@ jobs:
     # docs (other)
     - name: "Create documentation (other)"
       run: |
-        docker run -i -v "$GITHUB_WORKSPACE:/app" parsertongue/mkdocs:latest mkdocs build -c
+        mkdocs build -c
     - name: Deploy docs
       # FIXME: re-enable later
       #if: github.ref == 'refs/heads/main'

--- a/app/ai/lum/odinson/rest/requests/GrammarRequest.scala
+++ b/app/ai/lum/odinson/rest/requests/GrammarRequest.scala
@@ -10,6 +10,7 @@ case class GrammarRequest(
   pretty: Option[Boolean] = None
 )
 
+// Deprecated
 object GrammarRequest {
   implicit val fmt: OFormat[GrammarRequest] = Json.format[GrammarRequest]
   implicit val read: Reads[GrammarRequest] = Json.reads[GrammarRequest]

--- a/app/ai/lum/odinson/rest/requests/SimplePatternsRequest.scala
+++ b/app/ai/lum/odinson/rest/requests/SimplePatternsRequest.scala
@@ -5,11 +5,11 @@ import play.api.libs.json._
 case class SimplePatternsRequest(
   patterns: List[String],
   metadataQuery: Option[String] = None,
-  label: Option[String], 
-  commit: Option[Boolean], 
-  prevDoc: Option[Int], 
-  prevScore: Option[Float], 
-  enriched: Boolean = false,
+  // label: Option[String] = None, 
+  // commit: Option[Boolean] = None, 
+  prevDoc: Option[Int] = None, 
+  prevScore: Option[Float] = None, 
+  enriched: Option[Boolean] = None,
   pretty: Option[Boolean] = None
 )
 

--- a/app/ai/lum/odinson/rest/requests/SimplePatternsRequest.scala
+++ b/app/ai/lum/odinson/rest/requests/SimplePatternsRequest.scala
@@ -1,0 +1,19 @@
+package ai.lum.odinson.rest.requests
+
+import play.api.libs.json._
+
+case class SimplePatternsRequest(
+  patterns: List[String],
+  metadataQuery: Option[String] = None,
+  label: Option[String], 
+  commit: Option[Boolean], 
+  prevDoc: Option[Int], 
+  prevScore: Option[Float], 
+  enriched: Boolean = false,
+  pretty: Option[Boolean] = None
+)
+
+object SimplePatternsRequest {
+  implicit val fmt: OFormat[SimplePatternsRequest] = Json.format[SimplePatternsRequest]
+  implicit val read: Reads[SimplePatternsRequest] = Json.reads[SimplePatternsRequest]
+}

--- a/app/ai/lum/odinson/rest/utils/ExceptionUtils.scala
+++ b/app/ai/lum/odinson/rest/utils/ExceptionUtils.scala
@@ -16,7 +16,7 @@ object ExceptionUtils {
     e: Throwable,
     message: Option[String] = None
   ): Result = {
-    println(s"e:\t${ApacheExceptionUtils.getStackTrace(e)}")
+    //println(s"e:\t${ApacheExceptionUtils.getStackTrace(e)}")
     val errorMsg: String = message match {
       // .getMessage , .getStackTrace , .getRootCause
       case None      => ApacheExceptionUtils.getMessage(e)

--- a/app/ai/lum/odinson/rest/utils/ExceptionUtils.scala
+++ b/app/ai/lum/odinson/rest/utils/ExceptionUtils.scala
@@ -16,6 +16,7 @@ object ExceptionUtils {
     e: Throwable,
     message: Option[String] = None
   ): Result = {
+    println(s"e:\t${ApacheExceptionUtils.getStackTrace(e)}")
     val errorMsg: String = message match {
       // .getMessage , .getStackTrace , .getRootCause
       case None      => ApacheExceptionUtils.getMessage(e)

--- a/app/ai/lum/odinson/rest/utils/StartEnd.scala
+++ b/app/ai/lum/odinson/rest/utils/StartEnd.scala
@@ -1,0 +1,3 @@
+package ai.lum.odinson.rest.utils
+
+case class StartEnd(start: Int, end: Int)

--- a/app/controllers/OdinsonController.scala
+++ b/app/controllers/OdinsonController.scala
@@ -583,7 +583,7 @@ class OdinsonController @Inject() (
           spr.metadataQuery,
           duration,
           results,
-          spr.enriched,
+          spr.enriched.getOrElse(false),
           config
         ))
         json.format(spr.pretty)

--- a/app/controllers/OdinsonController.scala
+++ b/app/controllers/OdinsonController.scala
@@ -390,7 +390,7 @@ class OdinsonController @Inject() (
     */
   def commitResults(
     engine: ExtractorEngine,
-    oq: String,
+    odinsonQuery: String,
     metadataQuery: Option[String],
     label: String = "Mention"
   ): Unit = {

--- a/app/controllers/OdinsonController.scala
+++ b/app/controllers/OdinsonController.scala
@@ -565,7 +565,7 @@ class OdinsonController @Inject() (
       val spr = request.body.asJson.get.as[SimplePatternsRequest]
       try {
         val patterns: List[OdinsonQuery] = spr.patterns.map(engine.compiler.mkQuery).toList
-        val disjunctiveQuery = new OdinOrQuery(patterns, fields = patterns.head.getField)
+        val disjunctiveQuery = new OdinOrQuery(patterns, field = patterns.head.getField)
         val oq = spr.metadataQuery match {
           case Some(pq) =>
             engine.compiler.mkQuery(disjunctiveQuery, pq)

--- a/app/controllers/OdinsonController.scala
+++ b/app/controllers/OdinsonController.scala
@@ -563,32 +563,31 @@ class OdinsonController @Inject() (
     ExtractorEngine.usingEngine(config) { engine =>
       // FIXME: replace .get with validation check
       val spr = request.body.asJson.get.as[SimplePatternsRequest]
-        try {
-          val patterns: List[OdinsonQuery] = spr.patterns.map(engine.compiler.mkQuery).toList
-          val disjunctiveQuery = new OdinOrQuery(patterns, fields = patterns.head.getField)
-          val oq = spr.metadataQuery match {
-            case Some(pq) =>
-              engine.compiler.mkQuery(disjunctiveQuery, pq)
-            case None =>
-              disjunctiveQuery
-          }
-          val start = System.currentTimeMillis()
-          val results: OdinResults = retrieveResults(engine, oq, spr.prevDoc, spr.prevScore)
-          val duration = (System.currentTimeMillis() - start) / 1000f // duration in seconds
+      try {
+        val patterns: List[OdinsonQuery] = spr.patterns.map(engine.compiler.mkQuery).toList
+        val disjunctiveQuery = new OdinOrQuery(patterns, fields = patterns.head.getField)
+        val oq = spr.metadataQuery match {
+          case Some(pq) =>
+            engine.compiler.mkQuery(disjunctiveQuery, pq)
+          case None =>
+            disjunctiveQuery
+        }
+        val start = System.currentTimeMillis()
+        val results: OdinResults = retrieveResults(engine, oq, spr.prevDoc, spr.prevScore)
+        val duration = (System.currentTimeMillis() - start) / 1000f // duration in seconds
 
-          // NOTE: no use of state here
+        // NOTE: no use of state here
 
-          val json = Json.toJson(engine.mkJson(
-            spr.patterns.map{ patt => s"(${patt})"}.mkString(" | "),
-            spr.metadataQuery,
-            duration,
-            results,
-            enriched,
-            config
-          ))
-          json.format(spr.pretty)
-        } catch handleNonFatal
-      }
+        val json = Json.toJson(engine.mkJson(
+          spr.patterns.map{ patt => s"(${patt})"}.mkString(" | "),
+          spr.metadataQuery,
+          duration,
+          results,
+          enriched,
+          config
+        ))
+        json.format(spr.pretty)
+      } catch handleNonFatal
     }
   }
 

--- a/app/controllers/OdinsonController.scala
+++ b/app/controllers/OdinsonController.scala
@@ -583,7 +583,7 @@ class OdinsonController @Inject() (
           spr.metadataQuery,
           duration,
           results,
-          enriched,
+          spr.enriched,
           config
         ))
         json.format(spr.pretty)

--- a/conf/routes
+++ b/conf/routes
@@ -23,7 +23,7 @@ GET     /api/execute/pattern            controllers.OdinsonController.runQuery(o
 POST     /api/execute/disjunction-of-patterns            controllers.OdinsonController.runDisjunctiveQuery()
 
 + nocsrf
-POST    /api/execute/grammar            controllers.OdinsonController.executeGrammar()
+POST    /api/execute/grammar            controllers.OdinsonController.executeGrammar(maxDocs: Option[Int], allowTriggerOverlaps: Option[Boolean], metadataQuery: Option[String], label: Option[String], pretty: Option[Boolean])
 
 # document json
 + nocsrf

--- a/conf/routes
+++ b/conf/routes
@@ -20,6 +20,9 @@ GET     /api                            controllers.OpenApiController.openAPI
 GET     /api/execute/pattern            controllers.OdinsonController.runQuery(odinsonQuery: String, metadataQuery: Option[String], label: Option[String], commit: Option[Boolean], prevDoc: Option[Int], prevScore: Option[Float], enriched: Boolean = false, pretty: Option[Boolean])
 
 + nocsrf
+POST     /api/execute/disjunction-of-patterns            controllers.OdinsonController.runDisjunctiveQuery()
+
++ nocsrf
 POST    /api/execute/grammar            controllers.OdinsonController.executeGrammar()
 
 # document json

--- a/public/schema/odinson.yaml
+++ b/public/schema/odinson.yaml
@@ -160,12 +160,75 @@ paths:
           An Odinson grammar.
         required: true
         content:
-          "application/json":
+          "plain/text":
             schema:
-              $ref: '#/components/schemas/OdinsonGrammarRequest'
-#      consumes:
-#        - application/json
+              type: string
+              example: |
+                vars:
+                  chunk: "([tag=/J.*/]{,3} [tag=/N.*/]+ (of [tag=DT]? [tag=/J.*/]{,3} [tag=/N.*/]+)?)"
 
+                rules:
+                  - name: xp
+                    label: XP
+                    type: basic
+                    priority: 1
+                    pattern: |
+                      [chunk=/.-NP/]+|[chunk=/.-ADVP/]+|[chunk=/.-VP/]+
+
+                  - name: xp-seq
+                    label: test
+                    type: basic
+                    priority: 2
+                    pattern: |
+                      @XP @XP
+
+                  - name: example-basic-rule
+                    type: basic
+                    priority: 1
+                    pattern: |
+                      (?<hypernym> ${chunk}) >nmod_such_as (?<hyponym> ${chunk})
+
+                  - name: example-event-rule
+                    type: event
+                    priority: 1
+                    pattern: |
+                      trigger = cause|increase|decrease|affect
+                      cause = >nsubj ${chunk}
+                      effect = >dobj ${chunk}
+                
+      parameters:
+        - name: maxDocs
+          in: query
+          description: |
+            The maximum number of sentences to execute the rules against.
+          schema:
+            type: integer
+            format: int32
+          example: 10
+        - name: allowTriggerOverlaps
+          in: query
+          description: |
+            Whether or not event arguments are permitted to overlap with the event's trigger. Defaults to false.
+          schema:
+            type: boolean
+            default: false
+          example: false
+        - name: metadataQuery
+          in: query
+          required: false
+          schema:
+            type: string
+          description: |
+            A query to filter Documents by their metadata before applying an Odinson grammar.
+          example: "character contains 'Special Agent'"
+        - name: label
+          in: query
+          required: false
+          schema:
+            type: string
+          description: |
+            Only return mentions matching the label (if provided).
+          #example: "character contains 'Special Agent'"
       responses:
         '200':
           description: Mentions matched by the grammar.

--- a/public/schema/odinson.yaml
+++ b/public/schema/odinson.yaml
@@ -112,6 +112,39 @@ paths:
               schema:
                 $ref: '#/components/schemas/QueryError'
 
+  /api/execute/disjunction-of-patterns:
+    post:
+      tags:
+        - search
+      summary: |
+        Composes a disjunction of Odinson queries (ex. A OR B OR C) and executes it against the corpus.
+      description: |
+        Composes a disjunction of Odinson queries (ex. A OR B OR C) and executes it against the corpus.  Optionally include a doc-level Lucene query to identify a subset of documents to which the query should be applied.
+      operationId: execute-disjunctive-pattern
+      requestBody:
+        description: |
+          a disjunction of patterns.
+        required: true
+        content:
+          "application/json":
+            schema:
+              $ref: '#/components/schemas/SimplePatternsRequest'
+      responses:
+        '200':
+          description: Paginated matches for the query.
+          content:
+            "application/json":
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BasicResults'
+        '400':
+          description: Syntax error in query.
+          content:
+            "application/json":
+              schema:
+                $ref: '#/components/schemas/QueryError'
+
   /api/execute/grammar:
     post:
       tags:
@@ -1081,6 +1114,49 @@ components:
                 roots: [ 2 ]
 
   schemas:
+    SimplePatternsRequest:
+      type: object
+      required:
+        - patterns
+      properties:
+        patterns:
+          type: array
+          description: A list of queries.
+          items:
+            type: string
+            description: A single odinson query.
+        metadataQuery:
+          $ref: '#/components/schemas/MetadataQuery'
+        label:
+          description: |
+            The label to use when committing mentions to the State.
+          schema:
+            type: string
+        commit:
+          description: |
+            Whether or not the results of this query should be committed to the State.
+          schema:
+            type: boolean
+        prevDoc:
+          description: |
+            The ID (`sentenceId`) for the last document (sentence) seen in the previous page of results.
+          required: false
+          schema:
+            type: integer
+            format: int32
+            # minimum: 1
+            # exclusiveMinimum: false
+            # maximum: 3
+            # exclusiveMaximum: false
+          #example: 1
+        prevScore:
+          description: |
+            The score for the last result seen in the previous page of results.
+          required: false
+          schema:
+            type: number
+            format: float
+          #example: 0.424
 
     OdinsonGrammarRequest:
       type: object

--- a/python/lum/odinson/doc.py
+++ b/python/lum/odinson/doc.py
@@ -30,6 +30,7 @@ class Field(BaseModel):
     type: Fields = pydantic.Field(alias="$type", default="ai.lum.odinson.Field")
     model_config = ConfigDict(use_enum_values=True, validate_default=True)
 
+
 class TokensField(Field):
     tokens: Tokens
     type: Literal[Fields.TOKENS_FIELD] = pydantic.Field(
@@ -196,11 +197,11 @@ class Sentence(BaseModel):
     def copy(self, fields: List[AnyField]) -> "Sentence":
         """Convenience method for easily copying an Odinson Sentence and replacing specific attributes"""
         return Sentence(
-          # validate and count tokens
-          numTokens=Sentence._count_tokens(fields), 
-          fields=fields
+            # validate and count tokens
+            numTokens=Sentence._count_tokens(fields),
+            fields=fields,
         )
-    
+
     @staticmethod
     def validate_fields(fields: List[AnyField]) -> bool:
         # validation
@@ -210,26 +211,28 @@ class Sentence(BaseModel):
                 num_tokens.add(len(f.tokens))
         # NOTE: this will also fail if no TokensField are present
         if len(num_tokens) != 1:
-            raise Exception(f"All TokensField for sentence should have same length, but found {len(num_tokens)}")
+            raise Exception(
+                f"All TokensField for sentence should have same length, but found {len(num_tokens)}"
+            )
         return True
-        
+
     @staticmethod
     def _count_tokens(fields: List[AnyField]) -> bool:
-      """Get count of tokens based on TokensField after first validating with Sentence.validate_fields"""
-      _ = Sentence.validate_fields(fields)
-      for f in fields:
-          if isinstance(f, TokensField):
-              return len(f.tokens)
-        
+        """Get count of tokens based on TokensField after first validating with Sentence.validate_fields"""
+        _ = Sentence.validate_fields(fields)
+        for f in fields:
+            if isinstance(f, TokensField):
+                return len(f.tokens)
+
     @staticmethod
     def from_fields(fields: List[AnyField]) -> "Sentence":
         """Create an Odinson Sentence from a collection of fields"""
         return Sentence(
-          # validate and count
-          numTokens=Sentence._count_tokens(fields), 
-          fields=fields
+            # validate and count
+            numTokens=Sentence._count_tokens(fields),
+            fields=fields,
         )
-    
+
     @staticmethod
     def from_tokens(tokens: List[Token]) -> "Sentence":
         """Create an Odinson Sentence from a collection Tokens"""
@@ -239,11 +242,11 @@ class Sentence(BaseModel):
                 value = fields_dict.get(k, [])
                 value.append(v)
                 fields_dict[k] = value
-        num_tokens = list({len(values) for values in fields_dict.items()}) 
+        num_tokens = list({len(values) for values in fields_dict.items()})
         assert num_tokens == 1, "All token attributes must have the same length"
         fields = [TokensField(name=k, tokens=toks) for k, toks in fields_dict.items()]
         return Sentence(numTokens=num_tokens[0], fields=fields)
-        
+
 
 class Document(BaseModel):
     """ai.lum.odinson.Document"""
@@ -304,10 +307,15 @@ class Document(BaseModel):
             with open(fp, "r") as f:
                 return Document(**json.loads(f.read()))
 
-    def copy(self, id: Optional[str] = None, metadata: Optional[List[AnyField]] = None, sentences: Optional[List[Sentence]] = None) -> "Document":
+    def copy(
+        self,
+        id: Optional[str] = None,
+        metadata: Optional[List[AnyField]] = None,
+        sentences: Optional[List[Sentence]] = None,
+    ) -> "Document":
         """Convenience method for easily copying an Odinson Document and replacing specific attributes"""
         return Document(
-          id=id or self.id,
-          metadata=metadata or self.metadata,
-          sentences=sentences or self.sentences
+            id=id or self.id,
+            metadata=metadata or self.metadata,
+            sentences=sentences or self.sentences,
         )

--- a/python/lum/odinson/rest/api.py
+++ b/python/lum/odinson/rest/api.py
@@ -116,13 +116,18 @@ class OdinsonBaseAPI:
         )
 
     def _post_text(
-        self, endpoint: str, text: str, headers: Optional[Dict[str, str]] = None
+        self, 
+        endpoint: str, 
+        text: str, 
+        params: Optional[Dict[str, Union[str,int]]] = None,
+        headers: Optional[Dict[str, str]] = None
     ) -> requests.Response:
         return requests.post(
             endpoint,
             # NOTE: data takes str & .json() returns json str
             # json=text,
             data=text,
+            params=params,
             headers=headers,
         )
 
@@ -270,13 +275,12 @@ class OdinsonBaseAPI:
         allow_trigger_overlaps: bool = False,
     ):
         endpoint = f"{self.address}/api/execute/grammar"
-        gr = GrammarRequest(
-            grammar=grammar,
-            metadataQuery=metadata_query,
-            maxDocs=max_docs,
-            allowTriggerOverlaps=allow_trigger_overlaps,
-        )
-        res = requests.post(endpoint, json=gr.dict())
+        params = {
+            "metadataQuery" : metadata_query,
+            "maxDocs" : max_docs,
+            "allowTriggerOverlaps" : allow_trigger_overlaps
+        }
+        res = self._post_text(endpoint=endpoint, text=grammar, params=params)
         # return GrammarResults.empty() if res.status_code != 200 else GrammarResults(**res.json())
         # FIXME: check status code and return error or empty results?
         return GrammarResults(**res.json())

--- a/python/lum/odinson/rest/api.py
+++ b/python/lum/odinson/rest/api.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 from typing import Any, Dict, Iterator, List, Literal, Optional, Text, Union
 from lum.odinson.doc import AnyField, Document, Sentence
-from lum.odinson.rest.responses import CorpusInfo, OdinsonErrors, ScoreDoc, Statistic, GrammarResults, Results
-from lum.odinson.rest.requests import GrammarRequest
+from lum.odinson.rest.responses import (
+    CorpusInfo,
+    OdinsonErrors,
+    ScoreDoc,
+    Statistic,
+    GrammarResults,
+    Results,
+)
+from lum.odinson.rest.requests import GrammarRequest, SimplePatternsRequest
 from pydantic import BaseModel
 from dataclasses import dataclass
 import pydantic
@@ -16,7 +23,6 @@ __all__ = ["OdinsonBaseAPI"]
 
 
 class OdinsonBaseAPI:
-
     def __init__(self, address: Text):
         self.address = address
 
@@ -115,9 +121,9 @@ class OdinsonBaseAPI:
         return requests.post(
             endpoint,
             # NOTE: data takes str & .json() returns json str
-            #json=text,
+            # json=text,
             data=text,
-            headers=headers
+            headers=headers,
         )
 
     def validate_document(self, doc: Document, strict: bool = True) -> bool:
@@ -261,20 +267,17 @@ class OdinsonBaseAPI:
         # A query to filter Documents by their metadata before applying an Odinson pattern.
         metadata_query: Optional[str] = None,
         max_docs: Optional[int] = 20,
-        allow_trigger_overlaps: bool = False
+        allow_trigger_overlaps: bool = False,
     ):
         endpoint = f"{self.address}/api/execute/grammar"
         gr = GrammarRequest(
             grammar=grammar,
             metadataQuery=metadata_query,
             maxDocs=max_docs,
-            allowTriggerOverlaps=allow_trigger_overlaps
+            allowTriggerOverlaps=allow_trigger_overlaps,
         )
-        res = requests.post(
-            endpoint,
-            json=gr.dict()
-        )
-        #return GrammarResults.empty() if res.status_code != 200 else GrammarResults(**res.json())
+        res = requests.post(endpoint, json=gr.dict())
+        # return GrammarResults.empty() if res.status_code != 200 else GrammarResults(**res.json())
         # FIXME: check status code and return error or empty results?
         return GrammarResults(**res.json())
 
@@ -296,14 +299,6 @@ class OdinsonBaseAPI:
         prev_score: Optional[float] = None,
     ) -> Iterator[ScoreDoc]:
         endpoint = f"{self.address}/api/execute/pattern"
-        params = {
-            "odinsonQuery": odinson_query,
-            "metadataQuery": metadata_query,
-            "label": label,
-            "commit": commit,
-            "prevDoc": prev_doc,
-            "prevScore": prev_score,
-        }
         seen = 0
         results: Results = self._search(
             odinson_query=odinson_query,
@@ -332,6 +327,60 @@ class OdinsonBaseAPI:
                 label=label,
                 commit=commit,
                 prev_doc=last.sentence_id,
+            )
+            # print(f"total_hits:\t{results.total_hits}")
+
+    def search_disjunction_of_patterns(
+        self,
+        # An Odinson pattern.
+        # Example: ["[lemma=pie] []", "[lemma=blarg]"]
+        patterns: list[str],
+        # A query to filter Documents by their metadata before applying an Odinson pattern.
+        metadata_query: Optional[str] = None,
+        # The label to use when committing mentions to the State.
+        # Example: character contains 'Special Agent'
+        label: Optional[str] = None,
+        # The ID (sentenceId) for the last document (sentence) seen in the previous page of results.
+        prev_doc: Optional[int] = None,
+        # The score for the last result seen in the previous page of results.
+        prev_score: Optional[float] = None,
+    ) -> Iterator[ScoreDoc]:
+        endpoint = f"{self.address}/api/execute/disjunction-of-patterns"
+
+        spr = SimplePatternsRequest(
+            patterns=patterns,
+            metadataQuery=metadata_query,
+            prevDoc=prev_doc,
+            prevScore=prev_score,
+        )
+        results: Results = Results(**requests.post(endpoint, json=spr.dict()).json())
+
+        seen = 0
+        total = results.total_hits
+        if total == 0:
+            return iter(())
+        last = results.score_docs[-1]
+        while seen < total:
+            for sd in results.score_docs:
+                seen += 1
+                last = sd
+                # print(f"{seen-1}/{total}")
+                # print(f"sd.document_id:\t{sd.document_id}")
+                # print(f"sd.sentence_id:\t{sd.sentence_id}\n")
+                # FIXME: should this be a Results() with a single doc?
+                yield sd
+            # paginate
+            nspr = SimplePatternsRequest(
+                patterns=patterns,
+                metadata_query=metadata_query,
+                label=label,
+                prev_doc=last.sentence_id,
+            )
+            results: Results = Results(
+                **requests.post(
+                    endpoint,
+                    json=nspr.dict(),
+                ).json()
             )
             # print(f"total_hits:\t{results.total_hits}")
 

--- a/python/lum/odinson/rest/api.py
+++ b/python/lum/odinson/rest/api.py
@@ -152,7 +152,7 @@ class OdinsonBaseAPI:
     ) -> Union[bool, OdinsonErrors]:
         """Inspects and validates an Odinson grammar"""
         endpoint = f"{self.address}/api/validate/grammar"
-        res = self._post_text(endpoint=endpoint, contents=grammar)
+        res = self._post_text(endpoint=endpoint, text=grammar)
         if res.status_code == 200:
             return OdinsonBaseAPI.status_code_to_bool(res.status_code)
         else:

--- a/python/lum/odinson/rest/docker.py
+++ b/python/lum/odinson/rest/docker.py
@@ -12,9 +12,16 @@ __all__ = ["DockerBasedOdinsonAPI"]
 
 
 class DockerBasedOdinsonAPI(OdinsonBaseAPI):
-    
     DEFAULT_TOKEN_ATTRIBUTES = [
-      "raw", "word", "norm", "lemma", "tag", "chunk", "entity", "incoming", "outgoing"
+        "raw",
+        "word",
+        "norm",
+        "lemma",
+        "tag",
+        "chunk",
+        "entity",
+        "incoming",
+        "outgoing",
     ]
 
     DEFAULT_IMAGE: str = "lumai/odinson-rest-api:latest"
@@ -30,14 +37,16 @@ class DockerBasedOdinsonAPI(OdinsonBaseAPI):
         keep_alive: bool = False,
         max_mem_gb: int = 2,
         file_encoding: str = "UTF-8",
-        token_attributes: Optional[List[str]] = None
+        token_attributes: Optional[List[str]] = None,
     ):
         self.client = docker.from_env()
         self.temp_dir = tempfile.mkdtemp()
         self.local_path: Optional[str] = local_path or self.temp_dir
         self.max_mem_gb: int = max_mem_gb
         self.file_encoding: str = file_encoding
-        self.token_attributes: List[str] = token_attributes or DockerBasedOdinsonAPI.DEFAULT_TOKEN_ATTRIBUTES
+        self.token_attributes: List[str] = (
+            token_attributes or DockerBasedOdinsonAPI.DEFAULT_TOKEN_ATTRIBUTES
+        )
         self.image_name: str = image_name
         self.local_port: int = local_port or DockerBasedOdinsonAPI.get_unused_port()
         self.keep_alive: bool = keep_alive
@@ -47,9 +56,16 @@ class DockerBasedOdinsonAPI(OdinsonBaseAPI):
         if self.is_running():
             self.container = self.client.containers.get(self.container_name)
             self.keep_alive = True
-            self.local_path: str = [entry.get("Source") for entry in self.container.attrs.get("Mounts", []) if entry.get("Destination", "???") == DockerBasedOdinsonAPI.ODINSON_INTERNAL_DATA_PATH][0]
+            self.local_path: str = [
+                entry.get("Source")
+                for entry in self.container.attrs.get("Mounts", [])
+                if entry.get("Destination", "???")
+                == DockerBasedOdinsonAPI.ODINSON_INTERNAL_DATA_PATH
+            ][0]
             self.image_name: str = self.container.image.tags[0]
-            self.local_port: int = self.client.api.port(self.container_name, DockerBasedOdinsonAPI.ODINSON_INTERNAL_PORT)
+            self.local_port: int = self.client.api.port(
+                self.container_name, DockerBasedOdinsonAPI.ODINSON_INTERNAL_PORT
+            )
         else:
             self.container = self.client.containers.run(
                 self.image_name,
@@ -58,18 +74,23 @@ class DockerBasedOdinsonAPI(OdinsonBaseAPI):
                 ports={DockerBasedOdinsonAPI.ODINSON_INTERNAL_PORT: self.local_port},
                 auto_remove=True,
                 detach=True,
-                volumes={self.local_path: {"bind": DockerBasedOdinsonAPI.ODINSON_INTERNAL_DATA_PATH, "mode": "rw"}},
+                volumes={
+                    self.local_path: {
+                        "bind": DockerBasedOdinsonAPI.ODINSON_INTERNAL_DATA_PATH,
+                        "mode": "rw",
+                    }
+                },
                 environment={
-                  #-Dodinson.compiler.allTokenFields=["a", "b", "c"]
-                  "_JAVA_OPTIONS": f"-Xmx{self.max_mem_gb}g -Dplay.server.pidfile.path=/dev/null -Dfile.encoding={self.file_encoding}",
-                  "ODINSON_TOKEN_ATTRIBUTES": ",".join(self.token_attributes)
-                }
+                    # -Dodinson.compiler.allTokenFields=["a", "b", "c"]
+                    "_JAVA_OPTIONS": f"-Xmx{self.max_mem_gb}g -Dplay.server.pidfile.path=/dev/null -Dfile.encoding={self.file_encoding}",
+                    "ODINSON_TOKEN_ATTRIBUTES": ",".join(self.token_attributes),
+                },
             )
         super().__init__(address=f"http://127.0.0.1:{self.local_port}")
-  
+
     # def __enter__(self):
     #     return self
-    
+
     # def __exit__(self, exception_type, exception_value, exception_traceback):
     #     # Exception handling here
     #     # close index
@@ -111,7 +132,7 @@ class DockerBasedOdinsonAPI(OdinsonBaseAPI):
                 return True
             except Exception as e:
                 print(f"Failed to kill {self.container_name}")
-                #print(e)
+                # print(e)
                 return False
 
     def __del__(self):

--- a/python/lum/odinson/rest/docker.py
+++ b/python/lum/odinson/rest/docker.py
@@ -65,7 +65,7 @@ class DockerBasedOdinsonAPI(OdinsonBaseAPI):
             self.image_name: str = self.container.image.tags[0]
             self.local_port: int = self.client.api.port(
                 self.container_name, DockerBasedOdinsonAPI.ODINSON_INTERNAL_PORT
-            )
+            )[0]["HostPort"]
         else:
             self.container = self.client.containers.run(
                 self.image_name,

--- a/python/lum/odinson/rest/requests.py
+++ b/python/lum/odinson/rest/requests.py
@@ -31,6 +31,7 @@ class SimplePatternsRequest(BaseModel):
     metadataQuery: typing.Optional[str] = None
     prevDoc: typing.Optional[int] = None
     prevScore: typing.Optional[float] = None
+    enriched: typing.Optional[bool] = None
     pretty: typing.Optional[bool] = None
 
     def model_dump(self, by_alias=True, **kwargs):

--- a/python/lum/odinson/rest/requests.py
+++ b/python/lum/odinson/rest/requests.py
@@ -1,17 +1,37 @@
 from __future__ import annotations
-from typing import Optional
+import typing
 from pydantic import BaseModel, ConfigDict
 
 
-__all__ = ["GrammarRequest"]
+__all__ = ["GrammarRequest", "SimplePatternsRequest"]
 
 
 class GrammarRequest(BaseModel):
     grammar: str
-    metadataQuery: Optional[str] = None
-    maxDocs: Optional[int] = None
-    allowTriggerOverlaps: Optional[bool] = None
-    pretty: Optional[bool] = None
+    metadataQuery: typing.Optional[str] = None
+    maxDocs: typing.Optional[int] = None
+    allowTriggerOverlaps: typing.Optional[bool] = None
+    pretty: typing.Optional[bool] = None
+
+    def model_dump(self, by_alias=True, **kwargs):
+        return super().model_dump(by_alias=by_alias, **kwargs)
+
+    def model_dump_json(self, by_alias=True, **kwargs):
+        return super().model_dump_json(by_alias=by_alias, **kwargs)
+
+    def dict(self, **kwargs):
+        return self.model_dump(**kwargs)
+
+    def json(self, **kwargs):
+        return self.model_dump_json(**kwargs)
+
+
+class SimplePatternsRequest(BaseModel):
+    patterns: list[str]
+    metadataQuery: typing.Optional[str] = None
+    prevDoc: typing.Optional[int] = None
+    prevScore: typing.Optional[float] = None
+    pretty: typing.Optional[bool] = None
 
     def model_dump(self, by_alias=True, **kwargs):
         return super().model_dump(by_alias=by_alias, **kwargs)

--- a/python/lum/odinson/rest/responses.py
+++ b/python/lum/odinson/rest/responses.py
@@ -18,9 +18,8 @@ mq_desc = pydantic.Field(
     default=None,
 )
 
-duration_desc = pydantic.Field(
-    description="The query's execution time (in seconds)"
-)
+duration_desc = pydantic.Field(description="The query's execution time (in seconds)")
+
 
 class OdinsonErrors(BaseModel):
     errors: List[str]
@@ -76,6 +75,7 @@ class EventMatch(BaseMatch):
 class NamedCaptureMatch(BaseMatch):
     named_captures: List[NamedCapture] = pydantic.Field(alias="namedCaptures")
 
+
 class ScoreDoc(BaseModel):
     sentence_id: int = pydantic.Field(
         alias="sentenceId", description="The internal ID for this Odinson Document."
@@ -100,6 +100,7 @@ class ScoreDoc(BaseModel):
             # FIXME: should this be joined on whitespace?
             yield " ".join(self.words[m.start : m.end])
 
+
 # class OdinsonSpan(BaseModel):
 #     start: int = pydantic.Field(description="")
 #     end: int = pydantic.Field(description="")
@@ -107,27 +108,35 @@ class ScoreDoc(BaseModel):
 #     span: OdinsonSpan = pydantic.Field(description="")
 #     captures: List[OdinsonSpan] = pydantic.Field(description="")
 
+
 class BaseMention(BaseModel):
     label: str = pydantic.Field(description="The label for this Mention")
     sentence_id: int = pydantic.Field(
         alias="sentenceId", description="The internal ID for this Odinson Document."
     )
     documentId: str = pydantic.Field(
-        alias="documentId", description="The parent document's ID as provided at index time."
+        alias="documentId",
+        description="The parent document's ID as provided at index time.",
     )
     sentence_index: int = pydantic.Field(
-        alias="sentenceIndex", description="The positional index (0-based) of the matched sentence in some Odinson Document."
+        alias="sentenceIndex",
+        description="The positional index (0-based) of the matched sentence in some Odinson Document.",
     )
-    words: List[str] = pydantic.Field(description="The words of the sentence."
+    words: List[str] = pydantic.Field(description="The words of the sentence.")
+    found_by: str = pydantic.Field(
+        alias="foundBy", description="The name of the rule that produced this match."
     )
-    found_by: str = pydantic.Field( alias="foundBy", description="The name of the rule that produced this match."
+    match: List[Union[EventMatch, NamedCaptureMatch, BaseMatch]] = pydantic.Field(
+        description="The Mention representing the match."
     )
-    match: List[Union[EventMatch, NamedCaptureMatch, BaseMatch]] = pydantic.Field(description="The Mention representing the match.")
+
 
 class GrammarResults(BaseModel):
     metadata_query: Optional[str] = mq_desc
     duration: float = duration_desc
-    allow_trigger_overlaps: bool = pydantic.Field(alias="allowTriggerOverlaps", description="")
+    allow_trigger_overlaps: bool = pydantic.Field(
+        alias="allowTriggerOverlaps", description=""
+    )
     mentions: List[BaseMention]
 
     def model_dump(self, by_alias=True, **kwargs):
@@ -141,7 +150,9 @@ class GrammarResults(BaseModel):
 
     def json(self, **kwargs):
         return self.model_dump_json(**kwargs)
+
     # TODO: add convenience methods to get all matched spans
+
 
 class Results(BaseModel):
     odinson_query: str = pydantic.Field(
@@ -156,7 +167,6 @@ class Results(BaseModel):
     score_docs: List[ScoreDoc] = pydantic.Field(
         alias="scoreDocs", description="The matches"
     )
-
 
 
 #     # The name of the rule which matched this Mention.

--- a/python/lum/odinson/tests/test_odinson_document.py
+++ b/python/lum/odinson/tests/test_odinson_document.py
@@ -16,20 +16,21 @@ class TestOdinsonDocument(unittest.TestCase):
         )
 
     def test_property_access(self):
-        """odinson.Document should store token attributes for easy access via doc.attribute_name.
-        """
+        """odinson.Document should store token attributes for easy access via doc.attribute_name."""
         od = odinson.Document.from_file(TEST_DOC_PATH)
         self.assertTrue(
             len(od.lemma) > 0, f"doc.lemma should not be empty, but returned {od.lemma}"
         )
-    
+
     def test_copy(self):
         """odinson.Document.copy() should produce copies with only the specified changes."""
         _od = odinson.Document.from_file(TEST_DOC_PATH)
         od = _od.copy(id="blarg")
         self.assertTrue(
-            _od.id != od.id, f"Doc ID of original and clone should differ, but clone's ID was {od.id}"
+            _od.id != od.id,
+            f"Doc ID of original and clone should differ, but clone's ID was {od.id}",
         )
         self.assertTrue(
-            all(_od.sentences[i] == od.sentences[i] for i in range(len(_od.sentences))), f"Sentences of original and clone differing only in Doc ID should be identical"
+            all(_od.sentences[i] == od.sentences[i] for i in range(len(_od.sentences))),
+            f"Sentences of original and clone differing only in Doc ID should be identical",
         )

--- a/python/lum/odinson/tests/test_odinson_sentence.py
+++ b/python/lum/odinson/tests/test_odinson_sentence.py
@@ -9,8 +9,7 @@ import pytest
 # see https://docs.python.org/3/library/unittest.html#basic-example
 class TestOdinsonSentence(unittest.TestCase):
     def test_property_access(self):
-        """odinson.Sentence should store token attributes for easy access via sent.attribute_name.
-        """
+        """odinson.Sentence should store token attributes for easy access via sent.attribute_name."""
         od = odinson.Document.from_file(TEST_DOC_PATH)
         s = od.sentences[0]
         self.assertTrue(

--- a/test/controllers/OdinsonControllerSpec.scala
+++ b/test/controllers/OdinsonControllerSpec.scala
@@ -212,9 +212,9 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Injec
 
     }
 
-    // "process a pattern of disjunctive queries using the runDisjunctiveQueries method with a metadataQuery" in {
+    // "process a pattern of disjunctive queries using the runDisjunctiveQuery method with a metadataQuery" in {
 
-    //   val res1 = controller.runDisjunctiveQueries(
+    //   val res1 = controller.runDisjunctiveQuery(
     //     odinsonQueries = List("[lemma=pie]", "[lemma=noodles]"),
     //     metadataQuery = Some("character contains '/Maj.*/'"),
     //     label = None,
@@ -230,7 +230,7 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Injec
     //   // println(contentAsJson(res1))
     //   noResults(contentAsJson(res1)) mustBe true
 
-    //   val res2 = controller.runDisjunctiveQueries(
+    //   val res2 = controller.runDisjunctiveQuery(
     //     odinsonQuery = List("[lemma=pie]", "[lemma=noodles]"),
     //     metadataQuery = Some("character contains 'Special Agent'"),
     //     label = None,
@@ -246,9 +246,9 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Injec
     //   hasResults(contentAsJson(res2)) mustBe true
     // }
 
-    // "process a disjunction of queries using the runDisjunctiveQueries method without a metadataQuery" in {
+    // "process a disjunction of queries using the runDisjunctiveQuery method without a metadataQuery" in {
 
-    //   val res = controller.runDisjunctiveQueries(
+    //   val res = controller.runDisjunctiveQuery(
     //     odinsonQueries = List("[lemma=be] []", "[lemma=blarg]"),
     //     metadataQuery = None,
     //     label = None,
@@ -274,7 +274,7 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Injec
       )
 
       val response =
-        controller.runDisjunctiveQueries().apply(FakeRequest(POST, "/execute/disjunction-of-patterns").withJsonBody(body))
+        controller.runDisjunctiveQuery().apply(FakeRequest(POST, "/execute/disjunction-of-patterns").withJsonBody(body))
       status(response) mustBe OK
       contentType(response) mustBe Some("application/json")
 

--- a/test/controllers/OdinsonControllerSpec.scala
+++ b/test/controllers/OdinsonControllerSpec.scala
@@ -180,11 +180,11 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Injec
 
     }
 
-    "process a pattern query using the runQuery method with a metadataQuery" in {
+    "process a pattern query using the runQuery method without a metadataQuery" in {
 
-      val res1 = controller.runQuery(
-        odinsonQuery = "[lemma=pie]",
-        metadataQuery = Some("character contains '/Maj.*/'"),
+      val res = controller.runQuery(
+        odinsonQuery = "[lemma=be] []",
+        metadataQuery = None,
         label = None,
         commit = None,
         prevDoc = None,
@@ -193,28 +193,13 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Injec
         pretty = None
       ).apply(FakeRequest(GET, "/pattern"))
 
-      status(res1) mustBe OK
-      contentType(res1) mustBe Some("application/json")
-      // println(contentAsJson(res1))
-      noResults(contentAsJson(res1)) mustBe true
+      status(res) mustBe OK
+      contentType(res) mustBe Some("application/json")
+      Helpers.contentAsString(res) must include("core")
 
-      val res2 = controller.runQuery(
-        odinsonQuery = "[lemma=pie]",
-        metadataQuery = Some("character contains 'Special Agent'"),
-        label = None,
-        commit = None,
-        prevDoc = None,
-        prevScore = None,
-        enriched = false,
-        pretty = None
-      ).apply(FakeRequest(GET, "/pattern"))
-
-      status(res2) mustBe OK
-      contentType(res2) mustBe Some("application/json")
-      hasResults(contentAsJson(res2)) mustBe true
     }
 
-    "process a pattern query by accessing the /api/execute/pattern endpoint" in {
+    "process a pattern query by calling the /api/execute/pattern endpoint" in {
       // the pattern used in this test: "[lemma=be] []"
       val result = route(
         app,
@@ -225,6 +210,77 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Injec
       contentType(result) mustBe Some("application/json")
       Helpers.contentAsString(result) must include("core")
 
+    }
+
+    // "process a pattern of disjunctive queries using the runDisjunctiveQueries method with a metadataQuery" in {
+
+    //   val res1 = controller.runDisjunctiveQueries(
+    //     odinsonQueries = List("[lemma=pie]", "[lemma=noodles]"),
+    //     metadataQuery = Some("character contains '/Maj.*/'"),
+    //     label = None,
+    //     commit = None,
+    //     prevDoc = None,
+    //     prevScore = None,
+    //     enriched = false,
+    //     pretty = None
+    //   ).apply(FakeRequest(POST, "/disjunction-of-patterns"))
+
+    //   status(res1) mustBe OK
+    //   contentType(res1) mustBe Some("application/json")
+    //   // println(contentAsJson(res1))
+    //   noResults(contentAsJson(res1)) mustBe true
+
+    //   val res2 = controller.runDisjunctiveQueries(
+    //     odinsonQuery = List("[lemma=pie]", "[lemma=noodles]"),
+    //     metadataQuery = Some("character contains 'Special Agent'"),
+    //     label = None,
+    //     commit = None,
+    //     prevDoc = None,
+    //     prevScore = None,
+    //     enriched = false,
+    //     pretty = None
+    //   ).apply(FakeRequest(POST, "/disjunction-of-patterns"))
+
+    //   status(res2) mustBe OK
+    //   contentType(res2) mustBe Some("application/json")
+    //   hasResults(contentAsJson(res2)) mustBe true
+    // }
+
+    // "process a disjunction of queries using the runDisjunctiveQueries method without a metadataQuery" in {
+
+    //   val res = controller.runDisjunctiveQueries(
+    //     odinsonQueries = List("[lemma=be] []", "[lemma=blarg]"),
+    //     metadataQuery = None,
+    //     label = None,
+    //     commit = None,
+    //     prevDoc = None,
+    //     prevScore = None,
+    //     enriched = false,
+    //     pretty = None
+    //   ).apply(FakeRequest(POST, "/disjunction-of-patterns"))
+
+    //   status(res) mustBe OK
+    //   contentType(res) mustBe Some("application/json")
+    //   Helpers.contentAsString(res) must include("core")
+
+    // }
+
+    "process a disjunction of queries by calling the /api/execute/disjunction-of-patterns endpoint" in {
+
+      val body = Json.obj(
+        // format: off
+        "odinsonQueries"       -> List("[lemma=be] []", "[lemma=blarg]")
+        // format: on
+      )
+
+      val response =
+        controller.runDisjunctiveQueries().apply(FakeRequest(POST, "/execute/disjunction-of-patterns").withJsonBody(body))
+      status(response) mustBe OK
+      contentType(response) mustBe Some("application/json")
+
+      status(result) mustBe OK
+      contentType(result) mustBe Some("application/json")
+      Helpers.contentAsString(result) must include("core")
     }
 
     "execute a grammar using the executeGrammar method" in {

--- a/test/controllers/OdinsonControllerSpec.scala
+++ b/test/controllers/OdinsonControllerSpec.scala
@@ -269,7 +269,7 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Injec
 
       val body = Json.obj(
         // format: off
-        "odinsonQueries"       -> List("[lemma=be] []", "[lemma=blarg]")
+        "patterns"       -> List("[lemma=be] []", "[lemma=blarg]")
         // format: on
       )
 
@@ -277,10 +277,6 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Injec
         controller.runDisjunctiveQuery().apply(FakeRequest(POST, "/execute/disjunction-of-patterns").withJsonBody(body))
       status(response) mustBe OK
       contentType(response) mustBe Some("application/json")
-
-      status(result) mustBe OK
-      contentType(result) mustBe Some("application/json")
-      Helpers.contentAsString(result) must include("core")
     }
 
     "execute a grammar using the executeGrammar method" in {

--- a/test/controllers/OdinsonControllerSpec.scala
+++ b/test/controllers/OdinsonControllerSpec.scala
@@ -7,20 +7,24 @@ import ai.lum.odinson.{ Document => OdinsonDocument, ExtractorEngine }
 import ai.lum.odinson.utils.exceptions.OdinsonException
 import ai.lum.odinson.rest.utils.OdinsonDocumentUtils._
 import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
-import org.scalatestplus.play.guice._
-import play.api.test.Helpers._
 import org.apache.commons.io.FileUtils
 //import org.scalatest.TestData
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json._
-import org.scalatestplus.play._
+import play.api.mvc._
 import play.api.test._
+import play.api.test.Helpers._
+import org.scalatestplus.play._
+import org.scalatestplus.play.guice._
 
 import scala.reflect.io.Directory
 
+
 // with GuiceOneAppPerTest
 class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Injecting {
+
+  // implicit lazy val materializer: Materializer = app.materializer
 
   val defaultConfig: Config = ConfigFactory.load("test.conf")
 
@@ -32,7 +36,7 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Injec
   try {
     FileUtils.copyDirectory(srcDir, tmpFolder)
   } catch {
-    case e: IOException =>
+    case _: IOException =>
       throw OdinsonException(s"Can't copy resources directory ${srcDir}")
   }
 
@@ -260,35 +264,27 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Injec
       contentType(response) mustBe Some("application/json")
     }
 
-    "execute a grammar using the executeGrammar method" in {
+    // "execute a grammar using the executeGrammar method" in {
 
-      val ruleString =
-        s"""
-           |rules:
-           | - name: "example"
-           |   label: GrammaticalSubject
-           |   type: event
-           |   pattern: |
-           |     trigger  = [tag=/VB.*/]
-           |     subject  = >nsubj []
-           |
-        """.stripMargin
+    //   val ruleString =
+    //     s"""
+    //        |rules:
+    //        | - name: "example"
+    //        |   label: GrammaticalSubject
+    //        |   type: event
+    //        |   pattern: |
+    //        |     trigger  = [tag=/VB.*/]
+    //        |     subject  = >nsubj []
+    //        |
+    //     """.stripMargin
 
-      // val body = Json.obj(
-      //   // format: off
-      //   "grammar"              -> ruleString,
-      //   "pageSize"             -> 10,
-      //   "allowTriggerOverlaps" -> false
-      //   // format: on
-      // )
-
-      val response =
-        controller.executeGrammar().apply(FakeRequest(POST, "/grammar").withJsonBody(ruleString))
-      status(response) mustBe OK
-      contentType(response) mustBe Some("application/json")
-      Helpers.contentAsString(response) must include("vision")
-
-    }
+    //   val response =
+    //     controller.executeGrammar().apply(FakeRequest(POST, "/api/execute/grammar?pageSize=10&allowTriggerOverlaps=false").withTextBody(ruleString))
+    //   // println(response)
+    //   status(response) mustBe OK
+    //   contentType(response) mustBe Some("application/json")
+    //   Helpers.contentAsString(response) must include("vision")
+    // }
 
     "execute a grammar using the /api/execute/grammar endpoint" in {
 
@@ -312,7 +308,10 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Injec
       //   // format: on
       // )
 
-      val response = route(app, FakeRequest(POST, "/api/execute/grammar").withJsonBody(ruleString)).get
+      val request = FakeRequest(POST, "/api/execute/grammar?pageSize=10&allowTriggerOverlaps=false").withTextBody(ruleString)
+      println(s"request:\t${request}")
+      println(s"app:\t${app}")
+      val Some(response) = route(app, request)
 
       status(response) mustBe OK
       contentType(response) mustBe Some("application/json")
@@ -336,7 +335,7 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Injec
       // val body1 =
       //   Json.obj("grammar" -> ruleString1, "pageSize" -> 10, "allowTriggerOverlaps" -> false)
 
-      val response1 = route(app, FakeRequest(POST, "/api/execute/grammar").withJsonBody(ruleString1)).get
+      val response1 = route(app, FakeRequest(POST, "/api/execute/grammar").withTextBody(ruleString1)).get
 
       status(response1) mustBe OK
       contentType(response1) mustBe Some("application/json")
@@ -357,7 +356,7 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Injec
       // val body2 =
       //   Json.obj("grammar" -> ruleString2, "pageSize" -> 10, "allowTriggerOverlaps" -> false)
 
-      val response2 = route(app, FakeRequest(POST, "/api/execute/grammar").withJsonBody(ruleString2)).get
+      val response2 = route(app, FakeRequest(POST, "/api/execute/grammar").withTextBody(ruleString2)).get
 
       status(response2) mustBe OK
       contentType(response2) mustBe Some("application/json")

--- a/test/controllers/OdinsonControllerSpec.scala
+++ b/test/controllers/OdinsonControllerSpec.scala
@@ -180,25 +180,6 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Injec
 
     }
 
-    "process a pattern query using the runQuery method without a metadataQuery" in {
-
-      val res = controller.runQuery(
-        odinsonQuery = "[lemma=be] []",
-        metadataQuery = None,
-        label = None,
-        commit = None,
-        prevDoc = None,
-        prevScore = None,
-        enriched = false,
-        pretty = None
-      ).apply(FakeRequest(GET, "/pattern"))
-
-      status(res) mustBe OK
-      contentType(res) mustBe Some("application/json")
-      Helpers.contentAsString(res) must include("core")
-
-    }
-
     "process a pattern query by calling the /api/execute/pattern endpoint" in {
       // the pattern used in this test: "[lemma=be] []"
       val result = route(

--- a/test/controllers/OdinsonControllerSpec.scala
+++ b/test/controllers/OdinsonControllerSpec.scala
@@ -274,16 +274,16 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Injec
            |
         """.stripMargin
 
-      val body = Json.obj(
-        // format: off
-        "grammar"              -> ruleString,
-        "pageSize"             -> 10,
-        "allowTriggerOverlaps" -> false
-        // format: on
-      )
+      // val body = Json.obj(
+      //   // format: off
+      //   "grammar"              -> ruleString,
+      //   "pageSize"             -> 10,
+      //   "allowTriggerOverlaps" -> false
+      //   // format: on
+      // )
 
       val response =
-        controller.executeGrammar().apply(FakeRequest(POST, "/grammar").withJsonBody(body))
+        controller.executeGrammar().apply(FakeRequest(POST, "/grammar").withJsonBody(ruleString))
       status(response) mustBe OK
       contentType(response) mustBe Some("application/json")
       Helpers.contentAsString(response) must include("vision")
@@ -304,15 +304,15 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Injec
            |
         """.stripMargin
 
-      val body = Json.obj(
-        // format: off
-        "grammar"              -> ruleString,
-        "pageSize"             -> 10,
-        "allowTriggerOverlaps" -> false
-        // format: on
-      )
+      // val body = Json.obj(
+      //   // format: off
+      //   "grammar"              -> ruleString,
+      //   "pageSize"             -> 10,
+      //   "allowTriggerOverlaps" -> false
+      //   // format: on
+      // )
 
-      val response = route(app, FakeRequest(POST, "/api/execute/grammar").withJsonBody(body)).get
+      val response = route(app, FakeRequest(POST, "/api/execute/grammar").withJsonBody(ruleString)).get
 
       status(response) mustBe OK
       contentType(response) mustBe Some("application/json")
@@ -333,10 +333,10 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Injec
            |
         """.stripMargin
 
-      val body1 =
-        Json.obj("grammar" -> ruleString1, "pageSize" -> 10, "allowTriggerOverlaps" -> false)
+      // val body1 =
+      //   Json.obj("grammar" -> ruleString1, "pageSize" -> 10, "allowTriggerOverlaps" -> false)
 
-      val response1 = route(app, FakeRequest(POST, "/api/execute/grammar").withJsonBody(body1)).get
+      val response1 = route(app, FakeRequest(POST, "/api/execute/grammar").withJsonBody(ruleString1)).get
 
       status(response1) mustBe OK
       contentType(response1) mustBe Some("application/json")
@@ -354,10 +354,10 @@ class OdinsonControllerSpec extends PlaySpec with GuiceOneAppPerSuite with Injec
            |
         """.stripMargin
 
-      val body2 =
-        Json.obj("grammar" -> ruleString2, "pageSize" -> 10, "allowTriggerOverlaps" -> false)
+      // val body2 =
+      //   Json.obj("grammar" -> ruleString2, "pageSize" -> 10, "allowTriggerOverlaps" -> false)
 
-      val response2 = route(app, FakeRequest(POST, "/api/execute/grammar").withJsonBody(body2)).get
+      val response2 = route(app, FakeRequest(POST, "/api/execute/grammar").withJsonBody(ruleString2)).get
 
       status(response2) mustBe OK
       contentType(response2) mustBe Some("application/json")


### PR DESCRIPTION
## Summary of Changes

- Support compilation and execution of a disjunction of "basic" Odinson patterns
- POST `/api/execute/grammar` now takes a YAML grammar as the its text-based body w/ options specified via query params
- Changes to Mention JSON response:
  - `text` attributes and complete spans

### Related issues
- See https://gist.github.com/myedibleenso/bb383ba5ad6267eccfa7a46be7156c46
